### PR TITLE
Enable setting the working directory via the workdir() method

### DIFF
--- a/lib/Git/Raw/Repository.pm
+++ b/lib/Git/Raw/Repository.pm
@@ -265,9 +265,11 @@ sub walker { return Git::Raw::Walker -> create(@_) }
 
 Retrieve the complete path of the repository.
 
-=head2 workdir( )
+=head2 workdir( [$new_dir] )
 
-Retrieve the working directory of the repository.
+Retrieve the working directory of the repository.  If C<$new_dir> is
+passed, the working directory of the repository will be set to the
+directory.
 
 =head2 is_empty( )
 

--- a/xs/Repository.xs
+++ b/xs/Repository.xs
@@ -349,10 +349,19 @@ path(self)
 	OUTPUT: RETVAL
 
 SV *
-workdir(self)
+workdir(self, ...)
 	Repository self
 
-	CODE:
+        PROTOTYPE: $;$
+        CODE:
+
+                if (items == 2) {
+                        const char *new_path = SvPVbyte_nolen( ST(1) );
+                        const int update_gitlink = 1; // Also sets core.worktree
+                        int rc = git_repository_set_workdir(self, new_path, update_gitlink);
+			git_check_error(rc);
+		}
+
 		const char *path = git_repository_workdir(self);
 		RETVAL = newSVpv(path, 0);
 


### PR DESCRIPTION
This addresses issue #8.

I'm not sure what to do about the update_gitlink parameter.  I think 1 is the most sensible value.  But it should probably be made into an (optional) parameter anyway.

No tests yet.  Might get to that later, if you're interested in this.

-Jeff
