### PR TITLE
Add id method to Blob class

### DIFF
--- a/lib/Git/Raw/Blob.pm
+++ b/lib/Git/Raw/Blob.pm
@@ -35,6 +35,10 @@ Retrieve the raw content of a blob.
 
 Retrieve the size of the raw content of a blob.
 
+=head2 id( )
+
+Return the raw ID (the SHA-1 hash) of the blob.
+
 =head1 AUTHOR
 
 Alessandro Ghedini <alexbio@cpan.org>

--- a/t/12-blob.t
+++ b/t/12-blob.t
@@ -14,5 +14,6 @@ my $blob = $repo -> blob($buffer);
 
 is $blob -> content, $buffer;
 is $blob -> size, length $buffer;
+is $blob -> id, '30f51a3fba5274d53522d0f19748456974647b4f';
 
 done_testing;

--- a/xs/Blob.xs
+++ b/xs/Blob.xs
@@ -68,6 +68,16 @@ size(self)
 
 	OUTPUT: RETVAL
 
+SV *
+id(self)
+	Blob self
+
+	CODE:
+		const git_oid *oid = git_blob_id(self);
+		RETVAL = git_oid_to_sv((git_oid *) oid);
+
+	OUTPUT: RETVAL
+
 void
 DESTROY(self)
 	SV *self


### PR DESCRIPTION
The Git::Raw::Blob class is lacking an id method.  This pull request adds it.
