### PR TITLE
add is_tree and is_blob methods to ::Tree and ::Blob

### DIFF
--- a/lib/Git/Raw/Blob.pm
+++ b/lib/Git/Raw/Blob.pm
@@ -5,6 +5,9 @@ use warnings;
 
 use Git::Raw;
 
+sub is_blob { !0 }
+sub is_tree { !1 }
+
 =head1 NAME
 
 Git::Raw::Blob - Git blob class
@@ -38,6 +41,14 @@ Retrieve the size of the raw content of a blob.
 =head2 id( )
 
 Return the raw ID (the SHA-1 hash) of the blob.
+
+=head2 is_blob( )
+
+Returns true.
+
+=head2 is_tree( )
+
+Returns false.
 
 =head1 AUTHOR
 

--- a/lib/Git/Raw/Tree.pm
+++ b/lib/Git/Raw/Tree.pm
@@ -5,6 +5,9 @@ use warnings;
 
 use Git::Raw;
 
+sub is_tree { !0 }
+sub is_blob { !1 }
+
 =head1 NAME
 
 Git::Raw::Tree - Git tree class
@@ -43,6 +46,14 @@ Retrieve a L<Git::Raw::TreeEntry> object by path.
 
 Compute the L<Git::Raw::Diff> between two trees. If no C<$tree> is passed, the
 diff will be computed against the working directory.
+
+=head2 is_tree( )
+
+Returns true.
+
+=head2 is_blob( )
+
+Returns false.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Because currently, when you do e.g. `$tree->entry_byname( 'foo' )->object`, the only way to check what you got is to follow up with a `->isa( 'Git::Raw::Tree' )` or `->isa( 'Git::Raw::Blob' )`, which is damn ugly.
