### PR TITLE
Casting int to bool may be undefined (atleast prior to C99).

### DIFF
--- a/xs/Branch.xs
+++ b/xs/Branch.xs
@@ -80,11 +80,11 @@ upstream(self)
 
 	OUTPUT: RETVAL
 
-bool
+SV *
 is_head(self)
 	Branch self
 
 	CODE:
-		RETVAL = git_branch_is_head(self);
+		RETVAL = newSViv(git_branch_is_head(self));
 
 	OUTPUT: RETVAL

--- a/xs/Config.xs
+++ b/xs/Config.xs
@@ -60,7 +60,7 @@ bool(self, name, ...)
 				break;
 		}
 
-		RETVAL = (rc != GIT_ENOTFOUND) ? boolSV(value) : &PL_sv_undef;
+		RETVAL = (rc != GIT_ENOTFOUND) ? newSViv(value) : &PL_sv_undef;
 
 	OUTPUT: RETVAL
 

--- a/xs/Reference.xs
+++ b/xs/Reference.xs
@@ -153,21 +153,21 @@ target(self)
 
 	OUTPUT: RETVAL
 
-bool
+SV *
 is_branch(self)
 	Reference self
 
 	CODE:
-		RETVAL = git_reference_is_branch(self);
+		RETVAL = newSViv(git_reference_is_branch(self));
 
 	OUTPUT: RETVAL
 
-bool
+SV *
 is_remote(self)
 	Reference self
 
 	CODE:
-		RETVAL = git_reference_is_remote(self);
+		RETVAL = newSViv(git_reference_is_remote(self));
 
 	OUTPUT: RETVAL
 

--- a/xs/Remote.xs
+++ b/xs/Remote.xs
@@ -169,12 +169,12 @@ callbacks(self, callbacks)
 
 		git_remote_set_callbacks(self, &rcallbacks);
 
-bool
+SV *
 is_connected(self)
 	Remote self
 
 	CODE:
-		RETVAL = git_remote_connected(self);
+		RETVAL = newSViv(git_remote_connected(self));
 
 	OUTPUT: RETVAL
 

--- a/xs/Repository.xs
+++ b/xs/Repository.xs
@@ -469,21 +469,21 @@ workdir(self, ...)
 
 	OUTPUT: RETVAL
 
-bool
+SV *
 is_bare(self)
 	Repository self
 
 	CODE:
-		RETVAL = git_repository_is_bare(self);
+		RETVAL = newSViv(git_repository_is_bare(self));
 
 	OUTPUT: RETVAL
 
-bool
+SV *
 is_empty(self)
 	Repository self
 
 	CODE:
-		RETVAL = git_repository_is_empty(self);
+		RETVAL = newSViv(git_repository_is_empty(self));
 
 	OUTPUT: RETVAL
 


### PR DESCRIPTION
Casting int to bool may be undefined (at least prior to C99). If a compiler/platform does not have a boolean type, Perl will define it. We cannot assume that the actual underlying type supports conversion to and from integers i.e. it may be defined as a struct.
