### PR TITLE
The size of an array declared on the stack should be known at compile time (pre-C99)

### DIFF
--- a/xs/Commit.xs
+++ b/xs/Commit.xs
@@ -122,14 +122,14 @@ time(self)
 	Commit self
 
 	CODE:
+		char *buf;
 		git_time_t time = git_commit_time(self);
 
-		const int n = snprintf(NULL, 0, "%" PRId64, time);
-		char buf[n+1];
-
-		snprintf(buf, n+1, "%" PRId64, time);
+		Newx(buf, snprintf(NULL, 0, "%" PRId64, time)+1, char);
+		sprintf(buf, "%" PRId64, time);
 
 		RETVAL = newSVpv(buf, 0);
+		Safefree(buf);
 
 	OUTPUT: RETVAL
 

--- a/xs/Signature.xs
+++ b/xs/Signature.xs
@@ -65,14 +65,14 @@ time(self)
 	Signature self
 
 	CODE:
+		char *buf;
 		git_time_t time = self -> when.time;
 
-		const int n = snprintf(NULL, 0, "%" PRId64, time);
-		char buf[n + 1];
-
-		snprintf(buf, n + 1, "%" PRId64, time);
+		Newx(buf, snprintf(NULL, 0, "%" PRId64, time)+1, char);
+		sprintf(buf, "%" PRId64, time);
 
 		RETVAL = newSVpv(buf, 0);
+		Safefree(buf);
 
 	OUTPUT: RETVAL
 


### PR DESCRIPTION
Create the array on the heap to circumvent this restriction.
