### PR TITLE
MakeMaker.pm: Support compiling libgit2 with a 32-bit perl on a 64-bit system

### DIFF
--- a/inc/MakeMaker.pm
+++ b/inc/MakeMaker.pm
@@ -1,6 +1,7 @@
 package inc::MakeMaker;
 
 use Moose;
+use Config;
 
 extends 'Dist::Zilla::Plugin::MakeMaker::Awesome';
 
@@ -82,12 +83,14 @@ override _build_WriteMakefile_args => sub {
 
 	my $libgit2_objs = join ' ', @objs;
 
+	my $bits = $Config{longsize} == 4 ? '-m32' : '';
+
 	return +{
 		%{ super() },
 		INC	=> "-I. $inc",
 		LIBS	=> "-lrt",
 		DEFINE	=> $def,
-		CCFLAGS	=> '-Wall -Wno-unused-variable',
+		CCFLAGS	=> "$bits -Wall -Wno-unused-variable",
 		OBJECT	=> "$libgit2_objs \$(O_FILES)",
 	}
 };


### PR DESCRIPTION
This fixes the problem where we build `libgit2` without specifying the "bits". As an example, on my system (OS X 10.9), I built my own 32-bit perl, but compiler targets 64-bit by default. Without setting `-m32` linking errors occur.
