### PR TITLE
is_foo methods require 'require Git::Raw::xxxx’.

### DIFF
--- a/lib/Git/Raw.pm
+++ b/lib/Git/Raw.pm
@@ -8,6 +8,10 @@ XSLoader::load('Git::Raw', $Git::Raw::VERSION);
 
 use Git::Raw::Repository;
 
+# for use is_blob or is_tree methods.
+require Git::Raw::Blob;
+require Git::Raw::Tree;
+
 =head1 NAME
 
 Git::Raw - Perl bindings to the Git linkable library (libgit2)

--- a/t/05-tree.t
+++ b/t/05-tree.t
@@ -11,6 +11,9 @@ my $repo = Git::Raw::Repository -> open($path);
 my $head = $repo -> head -> target;
 my $tree = $head -> tree;
 
+ok $tree->is_tree;
+isnt $tree->is_blob, undef;
+
 my $entries = $tree -> entries;
 
 is $entries -> [0] -> name, 'test';

--- a/t/12-blob.t
+++ b/t/12-blob.t
@@ -16,4 +16,7 @@ is $blob -> content, $buffer;
 is $blob -> size, length $buffer;
 is $blob -> id, '30f51a3fba5274d53522d0f19748456974647b4f';
 
+ok $blob->is_blob;
+isnt $blob->is_tree, undef;
+
 done_testing;


### PR DESCRIPTION
Since 'is_foo' is a method of perl, it has an requirements 'require Git::Raw::Blob' or 'require  Git::Raw::Tree' in advance according to the type of an objects.

Since it calls in order that the users of is_foo may identify of which objects it is a type, according to the type of an objects, an import interface is not appropriate in a modules beforehand.
