### PR TITLE
MakeMaker.pm: Silence silly OS X deprecation warnings

### DIFF
--- a/inc/MakeMaker.pm
+++ b/inc/MakeMaker.pm
@@ -84,13 +84,18 @@ override _build_WriteMakefile_args => sub {
 	my $libgit2_objs = join ' ', @objs;
 
 	my $bits = $Config{longsize} == 4 ? '-m32' : '';
+	my $ccflags = "$bits -Wall -Wno-unused-variable";
+
+	if ($^O eq 'darwin') {
+		$ccflags .= ' -Wno-deprecated-declarations'
+	}
 
 	return +{
 		%{ super() },
 		INC	=> "-I. $inc",
 		LIBS	=> "-lrt",
 		DEFINE	=> $def,
-		CCFLAGS	=> "$bits -Wall -Wno-unused-variable",
+		CCFLAGS	=> $ccflags,
 		OBJECT	=> "$libgit2_objs \$(O_FILES)",
 	}
 };


### PR DESCRIPTION
This silences silly OS X warnings about using (apparently) deprecated OpenSSL functions.
