### PR TITLE
Cleanup ephemeral test files

### DIFF
--- a/t/07-remote.t
+++ b/t/07-remote.t
@@ -4,6 +4,7 @@ use Test::More;
 
 use Git::Raw;
 use Cwd qw(abs_path);
+use File::Path qw(rmtree);
 
 my $path = abs_path('t/test_repo');
 my $repo = Git::Raw::Repository -> open($path);
@@ -111,5 +112,9 @@ is $config -> str('user.email', $email), $email;
 
 $github -> update_tips;
 ok $update_tips;
+
+$repo = undef;
+rmtree ($path);
+ok ! -e $path;
 
 done_testing;

--- a/t/10-clone.t
+++ b/t/10-clone.t
@@ -12,6 +12,7 @@ use Test::More;
 use File::Spec;
 use Git::Raw;
 use Cwd qw(abs_path);
+use File::Path qw(rmtree);
 
 my $path;
 my $url = 'git://github.com/ghedo/p5-Git-Raw.git';
@@ -133,5 +134,11 @@ $repo = Git::Raw::Repository -> clone($url, $path, {
 ok ($received_bytes > 0);
 is $received_objects, $total_objects;
 is_deeply $states, $expected_states;
+
+rmtree(abs_path('t/test_repo_clone'));
+rmtree(abs_path('t/test_repo_clone_bare'));
+rmtree(abs_path('t/test_repo_clone_callbacks'));
+rmtree(abs_path('t/test_repo_disable_checkout'));
+rmtree(abs_path('t/test_repo_remote_name'));
 
 done_testing;

--- a/t/15-merge.t
+++ b/t/15-merge.t
@@ -6,6 +6,7 @@ use Git::Raw;
 use File::Spec;
 use File::Slurp;
 use Cwd qw(abs_path);
+use File::Path qw(rmtree);
 
 my $path = abs_path('t').'/merge_repo';
 my $repo = Git::Raw::Repository -> init($path, 0);
@@ -165,5 +166,9 @@ is $content, 'this is file1 on branch1 and branch2';
 is $repo -> state, "merge";
 $repo -> state_cleanup;
 is $repo -> state, "none";
+
+$repo = undef;
+rmtree ($path);
+ok ! -e $path;
 
 done_testing;

--- a/t/99-cleanup.t
+++ b/t/99-cleanup.t
@@ -1,0 +1,13 @@
+#!perl
+
+use Test::More;
+
+use Cwd qw(abs_path);
+use File::Path qw(rmtree);
+
+my $path = abs_path('t').'/test_repo';
+
+rmtree($path);
+ok ! -e $path;
+
+done_testing;


### PR DESCRIPTION
Currently, we are not cleaning up after ourselves after a test case run. This makes is cumbersome to rerun the test cases, you either have to run `dzil test` again or manually cleanup `t/*_repo`
