### PR TITLE
Correct reference counting of remotes

### DIFF
--- a/Raw.xs
+++ b/Raw.xs
@@ -46,7 +46,6 @@ typedef git_push * Push;
 typedef git_reference * Reference;
 typedef git_reflog * Reflog;
 typedef git_refspec * RefSpec;
-typedef git_remote * Remote;
 typedef git_repository * Repository;
 typedef git_signature * Signature;
 typedef git_tag * Tag;
@@ -64,6 +63,13 @@ typedef struct {
 
 typedef git_raw_filter * Filter;
 typedef git_filter_source * Filter_Source;
+
+typedef struct {
+	git_remote *remote;
+	git_raw_remote_callbacks callbacks;
+} git_raw_remote;
+
+typedef git_raw_remote * Remote;
 
 STATIC MGVTBL null_mg_vtbl = {
 	NULL, /* get */
@@ -223,6 +229,14 @@ STATIC SV *get_callback_option(HV *callbacks, const char *name) {
 	}
 
 	return NULL;
+}
+
+STATIC void git_init_remote_callbacks(git_raw_remote_callbacks *cbs) {
+	cbs -> credentials = NULL;
+	cbs -> progress = NULL;
+	cbs -> completion = NULL;
+	cbs -> transfer_progress = NULL;
+	cbs -> update_tips = NULL;
 }
 
 STATIC void git_clean_remote_callbacks(git_raw_remote_callbacks *cbs) {

--- a/t/07-remote.t
+++ b/t/07-remote.t
@@ -24,6 +24,7 @@ is $remotes[0] -> name, $name;
 is $remotes[0] -> url, $url;
 
 is $remotes[1], undef;
+@remotes = ();
 
 $name = 'github';
 $url  = 'git://github.com/ghedo/p5-Git-Raw.git';
@@ -115,6 +116,7 @@ $github -> update_tips;
 ok $update_tips;
 
 $repo = undef;
+$github = undef;
 rmtree $path;
 ok ! -e $path;
 

--- a/t/08-branch.t
+++ b/t/08-branch.t
@@ -71,6 +71,7 @@ is $branches -> [1] -> type, 'direct';
 is $branches -> [1] -> name, 'refs/heads/some_branch';
 
 if ($ENV{NETWORK_TESTING} or $ENV{RELEASE_TESTING}) {
+	is scalar(@$branches), 3;
 	is $branches -> [2] -> type, 'direct';
 	is $branches -> [2] -> name, 'refs/remotes/github/master';
 	ok $branches -> [2] -> is_remote;

--- a/xs/Push.xs
+++ b/xs/Push.xs
@@ -10,7 +10,7 @@ new(class, remote)
 		Push push;
 
 	CODE:
-		rc = git_push_new(&push, remote);
+		rc = git_push_new(&push, remote -> remote);
 		git_check_error(rc);
 
 		RETVAL = push;

--- a/xs/Repository.xs
+++ b/xs/Repository.xs
@@ -94,6 +94,8 @@ clone(class, url, path, opts)
 			&clone_opts
 		);
 
+		git_clean_remote_callbacks(&cbs);
+
 		git_check_error(rc);
 
 		RETVAL = repo;
@@ -744,7 +746,6 @@ remotes(self)
 		int rc;
 		size_t i;
 
-		Remote remote;
 		int num_remotes = 0;
 		git_strarray remotes;
 
@@ -758,9 +759,15 @@ remotes(self)
 
 		for (i = 0; i < remotes.count; i++) {
 			SV *perl_ref;
+			git_remote *r = NULL;
+			Remote remote = NULL;
 
-			rc = git_remote_load(&remote, repo, remotes.strings[i]);
+			rc = git_remote_load(&r, repo, remotes.strings[i]);
 			git_check_error(rc);
+
+			Newx(remote, 1, git_raw_remote);
+			git_init_remote_callbacks(&remote -> callbacks);
+			remote -> remote = r;
 
 			GIT_NEW_OBJ_WITH_MAGIC(
 				perl_ref, "Git::Raw::Remote", remote, SvRV(self)


### PR DESCRIPTION
We were accidentally overwriting the magic, causing the repository's
reference count to never be decremented.
