### PR TITLE
Added the support for accessing to the default configuration data.

### DIFF
--- a/lib/Git/Raw/Config.pm
+++ b/lib/Git/Raw/Config.pm
@@ -54,7 +54,7 @@ the loop.
 
 Reload the config files from disk.
 
-=head2 open_default( )
+=head2 default( )
 
 Returns a config object that indicates default config data ( global, XDG and system configuration files ).
 

--- a/xs/Config.xs
+++ b/xs/Config.xs
@@ -181,7 +181,7 @@ refresh(self)
 		git_check_error(rc);
 
 SV *
-open_default(class)
+default(class)
 	SV *class
 
 	PREINIT:
@@ -189,7 +189,7 @@ open_default(class)
 		Config cfg;
 
 	CODE:
-        rc = git_config_open_default(&cfg);
+		rc = git_config_open_default(&cfg);
 		git_check_error(rc);
 
 		RETVAL = sv_setref_pv(newSV(0), SvPVbyte_nolen(class), cfg);


### PR DESCRIPTION
Added a wrapper method for 'git_config_open_default' in config.h.

I would like to check a default configuration, before creating a repository. 

However, since there is still no idea of a test code.
