### PR TITLE
Fix tag type

### DIFF
--- a/Raw.xs
+++ b/Raw.xs
@@ -508,12 +508,19 @@ STATIC int git_stash_foreach_cb(size_t i, const char *msg, const git_oid *oid, v
 STATIC int git_tag_foreach_cbb(const char *name, git_oid *oid, void *payload) {
 	dSP;
 	int rv;
-	Tag tag;
+	git_object *tag;
+
 	SV *repo, *cb_arg;
 	git_foreach_payload *pl = payload;
 
-	int rc = git_tag_lookup(&tag, pl -> repo_ptr, oid);
+	int rc = git_object_lookup(&tag, pl -> repo_ptr, oid, GIT_OBJ_ANY);
 	git_check_error(rc);
+
+	if (git_object_type(tag) != GIT_OBJ_TAG) {
+		git_object_free(tag);
+
+		return 0;
+	}
 
 	ENTER;
 	SAVETMPS;

--- a/lib/Git/Raw/Repository.pm
+++ b/lib/Git/Raw/Repository.pm
@@ -570,7 +570,8 @@ sub tag { return Git::Raw::Tag -> create(@_) }
 
 =head2 tags( )
 
-Retrieve the list of L<Git::Raw::Tag> objects.
+Retrieve the list of L<Git::Raw::Tag> objects representing the
+repository's annotated Git tags. Lightweight tags are not returned.
 
 =cut
 

--- a/lib/Git/Raw/Tag.pm
+++ b/lib/Git/Raw/Tag.pm
@@ -31,7 +31,7 @@ Git::Raw::Tag - Git tag class
 
 =head1 DESCRIPTION
 
-A C<Git::Raw::Tag> represents a Git tag.
+A C<Git::Raw::Tag> represents an annotated Git tag.
 
 B<WARNING>: The API of this module is unstable and may change without warning
 (any change will be appropriately documented in the changelog).
@@ -40,8 +40,8 @@ B<WARNING>: The API of this module is unstable and may change without warning
 
 =head2 create( $repo, $name, $msg, $tagger, $target )
 
-Create a new tag given a name, a message, a L<Git::Raw::Signature> representing
-the tagger and a target object.
+Create a new annotated tag given a name, a message, a
+L<Git::Raw::Signature> representing the tagger and a target object.
 
 =head2 lookup( $repo, $id )
 

--- a/t/03-tag.t
+++ b/t/03-tag.t
@@ -49,6 +49,15 @@ is $tags[0] -> message, $tag_msg;
 is $tags[1], undef;
 
 $tags[0] -> delete;
+
+Git::Raw::Reference -> create("refs/tags/lightweight-tag", $repo, $commit);
+
+@tags = $repo -> tags;
+
+is $tags[0], undef;
+
+Git::Raw::Reference -> lookup("refs/tags/lightweight-tag", $repo) -> delete();
+
 is $repo -> tags, 0;
 
 done_testing;


### PR DESCRIPTION
It seems lightweight tags are broken: we have no code to directly create or delete them (though the Git::Raw::Reference code might work), but we also die in the Git::Raw::Repository::tags callback code if they exist, and that's a problem.

This is a minimal patch that simply ignores all lightweight tags.
