### PR TITLE
add Git::Raw::Tree::Entry::file_mode()

### DIFF
--- a/lib/Git/Raw/Filter/Source.pm
+++ b/lib/Git/Raw/Filter/Source.pm
@@ -28,8 +28,8 @@ Retrieve the path that the filter source data is coming from.
 
 =head2 file_mode( )
 
-Retrieve the file mode of the source file. If the mode is unknown,
-this will return 0.
+Retrieve the file mode of the source file, as an integer. If the mode
+is unknown, this will return 0.
 
 =head2 mode( )
 

--- a/lib/Git/Raw/Tree/Entry.pm
+++ b/lib/Git/Raw/Tree/Entry.pm
@@ -26,6 +26,11 @@ Retrieve the id of the tree entry, as string.
 
 Retrieve the filename of the tree entry.
 
+=head2 file_mode( )
+
+Retrieve the file mode of the tree entry, as an integer. For example,
+a normal file has mode 0100644 = 33188.
+
 =head2 object( $repo )
 
 Retrieve the object pointed by the tree entry.

--- a/t/05-tree.t
+++ b/t/05-tree.t
@@ -24,6 +24,10 @@ my $entries = $tree -> entries;
 
 is $entries -> [0] -> name, 'test';
 is $entries -> [1] -> name, 'test2';
+is $entries -> [2] -> name, 'test3';
+
+is $entries -> [0] -> file_mode, 0100644;
+is $entries -> [2] -> file_mode, 0040000;
 
 my $obj0 = $entries -> [0] -> object;
 

--- a/xs/Tree/Entry.xs
+++ b/xs/Tree/Entry.xs
@@ -27,6 +27,15 @@ name(self)
 	OUTPUT: RETVAL
 
 SV *
+file_mode(self)
+	Tree_Entry self
+
+	CODE:
+		RETVAL = newSViv(git_tree_entry_filemode(self));
+
+	OUTPUT: RETVAL
+
+SV *
 object(self)
 	SV *self
 


### PR DESCRIPTION
This is a feature request, not a bug report. As far as I can tell, we cannot distinguish between symlinks and regular files currently, and we should be able to.

I've used "file_mode" and integer (rather than octal string) representation in order to be consistent with existing code, but I'd prefer to use "filemode" to be consistent with libgit2 symbol names (I'm neutral on whether strings like "100644" would be better return values).

I think high-level ->is_symlink, ->is_executable functions would be nice, too. Let me know if you agree and I'll add them.
