### PR TITLE
Repository.xs: Added message() method

### DIFF
--- a/lib/Git/Raw/Repository.pm
+++ b/lib/Git/Raw/Repository.pm
@@ -695,6 +695,10 @@ Repository is applying patches or rebasing.
 Remove all the metadata associated with an ongoing command like merge, revert,
 cherry-pick, etc.
 
+=head2 message( )
+
+Retrieve the content of git's prepared message i.e. L<".git/MERGE_MSG">.
+
 =head2 is_empty( )
 
 Check if the repository is empty.

--- a/t/15-merge.t
+++ b/t/15-merge.t
@@ -118,6 +118,9 @@ write_file($file1, 'this is file1 on branch1 and branch2');
 $index -> add('test1');
 $index -> write;
 
+my $merge_msg = $repo -> message();
+is $merge_msg, "Merge branch 'branch2'\n";
+
 $commit = $repo -> commit("Merge commit!", $me, $me, [$master -> target, $commit2],
 	$repo -> lookup($index -> write_tree));
 

--- a/xs/Repository.xs
+++ b/xs/Repository.xs
@@ -1009,6 +1009,26 @@ state_cleanup(self)
 		git_check_error(rc);
 
 SV *
+message(self)
+	Repository self
+
+	PREINIT:
+		int rc;
+
+		git_buf buf = GIT_BUF_INIT_CONST(NULL, 0);
+
+	CODE:
+		rc = git_repository_message(&buf, self);
+		if (rc != GIT_OK)
+			git_buf_free(&buf);
+		git_check_error(rc);
+
+		RETVAL = newSVpv(buf.ptr, 0);
+		git_buf_free(&buf);
+
+	OUTPUT: RETVAL
+
+SV *
 is_bare(self)
 	Repository self
 


### PR DESCRIPTION
This PR exposes the `message()` method which is useful for merges where the user may want to get the contents of `.git/MERGE_MSG`.
