### PR TITLE
Repository.xs: merge_base() should fail if sv_isobject is false

### DIFF
--- a/t/15-merge.t
+++ b/t/15-merge.t
@@ -50,6 +50,7 @@ $repo -> checkout($repo -> head($master), {
 	}
 });
 
+ok (!eval {$repo -> merge_base("refs/heads/master", $commit1 -> id)});
 is $master -> target -> id, $repo -> merge_base($master, $commit1);
 
 my $r = $repo -> merge_analysis($branch1);

--- a/xs/Repository.xs
+++ b/xs/Repository.xs
@@ -664,6 +664,10 @@ merge_base(self, ...)
 					Perl_croak(aTHX_ "Expected a 'Git::Raw::Commit' "
 						"or 'Git::Raw::Reference'");
 				}
+			} else {
+				Safefree(oids);
+				Perl_croak(aTHX_ "Expected a 'Git::Raw::Commit' "
+					"or 'Git::Raw::Reference'");
 			}
 		}
 


### PR DESCRIPTION
So I missed a check here. Was only checking to make sure that the passed object was of the correct type, and never failing if it is not an object.
