### PR TITLE
Repository.xs: Added is_head_detached()

### DIFF
--- a/lib/Git/Raw/Repository.pm
+++ b/lib/Git/Raw/Repository.pm
@@ -711,6 +711,11 @@ Check if the repository is bare.
 
 Check if the repository is a shallow clone.
 
+=head2 is_head_detached( )
+
+Check if the repository's HEAD is detached, that is, it points directly to
+a commit.
+
 =head1 AUTHOR
 
 Alessandro Ghedini <alexbio@cpan.org>

--- a/t/01-repo.t
+++ b/t/01-repo.t
@@ -82,6 +82,7 @@ $config -> foreach(sub {
 });
 
 is $repo -> state, "none";
+is $repo -> is_head_detached, 0;
 
 my $commit_msg_file = File::Spec->catfile($repo -> path, 'MERGE_MSG');
 

--- a/xs/Repository.xs
+++ b/xs/Repository.xs
@@ -1053,6 +1053,15 @@ is_shallow(self)
 
 	OUTPUT: RETVAL
 
+SV *
+is_head_detached(self)
+	Repository self
+
+	CODE:
+		RETVAL = newSViv(git_repository_head_detached(self));
+
+	OUTPUT: RETVAL
+
 void
 DESTROY(self)
 	Repository self


### PR DESCRIPTION
This allows use to see if a repository's head is detached, without looping over all branches and checking if one of them is.
