### PR TITLE
Stash save should return undef if nothing was stashed

### DIFF
--- a/lib/Git/Raw/Stash.pm
+++ b/lib/Git/Raw/Stash.pm
@@ -21,7 +21,8 @@ B<WARNING>: The API of this module is unstable and may change without warning
 =head2 save( $repo, $stasher, $msg [, \@opts] )
 
 Save the local modifications to a new stash. Non-default options may be
-specified by providing the optional C<@opts> argument.
+specified by providing the optional C<@opts> argument. If files were stashed,
+this function will return a true value, otherwise C<undef>.
 
 Valid fields for the C<@opts> array are:
 

--- a/t/11-stash.t
+++ b/t/11-stash.t
@@ -20,7 +20,7 @@ my $email  = $config -> str('user.email');
 
 my $me = Git::Raw::Signature -> now($name, $email);
 
-$repo -> stash($me, 'some stash');
+ok ($repo -> stash($me, 'some stash'));
 
 Git::Raw::Stash -> foreach($repo, sub {
 	my ($i, $msg, $oid) = @_;
@@ -30,6 +30,8 @@ Git::Raw::Stash -> foreach($repo, sub {
 
 	0;
 });
+
+is $repo -> stash($me, 'some stash'), undef;
 
 Git::Raw::Stash -> drop($repo, 0);
 

--- a/xs/Stash.xs
+++ b/xs/Stash.xs
@@ -1,6 +1,6 @@
 MODULE = Git::Raw			PACKAGE = Git::Raw::Stash
 
-void
+SV *
 save(class, repo, stasher, msg, ...)
 	SV *class
 	Repository repo
@@ -41,7 +41,14 @@ save(class, repo, stasher, msg, ...)
 		}
 
 		rc = git_stash_save(&oid, repo -> repository, stasher, git_ensure_pv(msg, "msg"), stash_flags);
-		git_check_error(rc);
+		if (rc == GIT_ENOTFOUND) {
+			RETVAL = &PL_sv_undef;
+		} else {
+			git_check_error(rc);
+			RETVAL = newSViv(1);
+		}
+
+	OUTPUT: RETVAL
 
 void
 foreach(class, repo, cb)


### PR DESCRIPTION
It's not an error to not have stashed changes, return `undef`.
