### PR TITLE
Returning a non-zero value from a callback results in an error

### DIFF
--- a/Raw.xs
+++ b/Raw.xs
@@ -983,6 +983,9 @@ STATIC int git_config_foreach_cbb(const git_config_entry *entry, void *payload) 
 	FREETMPS;
 	LEAVE;
 
+	if (rv != 0)
+		rv = GIT_EUSER;
+
 	return rv;
 }
 
@@ -1007,6 +1010,9 @@ STATIC int git_stash_foreach_cb(size_t i, const char *msg, const git_oid *oid, v
 
 	FREETMPS;
 	LEAVE;
+
+	if (rv != 0)
+		rv = GIT_EUSER;
 
 	return rv;
 }
@@ -1047,6 +1053,9 @@ STATIC int git_tag_foreach_cbb(const char *name, git_oid *oid, void *payload) {
 
 	FREETMPS;
 	LEAVE;
+
+	if (rv != 0)
+		rv = GIT_EUSER;
 
 	return rv;
 }

--- a/xs/Stash.xs
+++ b/xs/Stash.xs
@@ -70,8 +70,8 @@ foreach(class, repo, cb)
 		rc = git_stash_foreach(
 			payload.repo_ptr -> repository, git_stash_foreach_cb, &payload
 		);
-
-		git_check_error(rc);
+		if (rc != GIT_EUSER)
+			git_check_error(rc);
 
 void
 drop(class, repo, index)


### PR DESCRIPTION
We should be passing `GIT_EUSER` to libgit2 and check for `GIT_EUSER` when the function returns.
