### PR TITLE
Return a Tree object from Index->write_tree()

### DIFF
--- a/Raw.xs
+++ b/Raw.xs
@@ -422,7 +422,7 @@ STATIC git_oid *git_sv_to_commitish(git_repository *repo, SV *sv, git_oid *oid) 
 		const char *commitish_name = NULL;
 
 		/* substr() may return a SVt_PVLV, need to perform some force majeur */
-		if (SvPOK(sv)) {
+		if (SvPOK(sv) || SvGAMAGIC(sv)) {
 			commitish_name = SvPVbyte(sv, len);
 		} else if (SvTYPE(sv) == SVt_PVLV) {
 			commitish_name = SvPVbyte_force(sv, len);
@@ -609,11 +609,13 @@ STATIC const char *git_ensure_pv_with_len(SV *sv, const char *identifier, STRLEN
 	const char *pv = NULL;
 	STRLEN real_len;
 
-	if (SvPOK(sv)) {
+	if (SvPOK(sv) || SvGAMAGIC(sv)) {
 		pv = SvPVbyte(sv, real_len);
 	} else if (SvTYPE(sv) == SVt_PVLV) {
 		pv = SvPVbyte_force(sv, real_len);
-	} else
+	}
+
+	if (pv == NULL)
 		croak_usage("Invalid type for '%s', expected a string", identifier);
 
 	if (len)

--- a/lib/Git/Raw.pm
+++ b/lib/Git/Raw.pm
@@ -10,6 +10,7 @@ use Git::Raw::Error;
 use Git::Raw::Error::Category;
 use Git::Raw::Reference;
 use Git::Raw::Repository;
+use Git::Raw::Tree;
 
 =for HTML
 <a href="https://travis-ci.org/jacquesg/p5-Git-Raw">

--- a/lib/Git/Raw/Index.pm
+++ b/lib/Git/Raw/Index.pm
@@ -103,7 +103,8 @@ Replace the index contente with C<$tree>.
 =head2 write_tree( [$repo] )
 
 Create a new tree from the index and write it to disk. C<$repo> optionally
-indicates which L<Git::Raw::Repository> the tree should be written to.
+indicates which L<Git::Raw::Repository> the tree should be written to. Returns
+a L<Git::Raw::Tree> object.
 
 =head2 checkout( [\%checkout_opts] )
 

--- a/lib/Git/Raw/Tree.pm
+++ b/lib/Git/Raw/Tree.pm
@@ -3,6 +3,9 @@ package Git::Raw::Tree;
 use strict;
 use warnings;
 
+use overload
+	'""'       => sub { return $_[0] -> id };
+
 use Git::Raw;
 
 =head1 NAME

--- a/t/02-commit.t
+++ b/t/02-commit.t
@@ -39,8 +39,8 @@ $index -> add_all({
 });
 $index -> write;
 
-my $tree_id = $index -> write_tree;
-my $tree    = $repo -> lookup($tree_id);
+my $tree = $index -> write_tree;
+isa_ok $tree, 'Git::Raw::Tree';
 
 my $non_existent = $repo -> lookup('123456789987654321');
 is $non_existent, undef;
@@ -188,8 +188,7 @@ write_file($file, 'this is a second test');
 $index -> add('test2');
 $index -> write;
 
-$tree_id = $index -> write_tree;
-$tree    = $repo -> lookup($tree_id);
+$tree = $index -> write_tree;
 
 $time = time();
 $me = Git::Raw::Signature -> default($repo);
@@ -248,8 +247,7 @@ write_file($file, 'this is a third test');
 $index -> add('test3/under/the/tree/test3');
 $index -> write;
 
-$tree_id = $index -> write_tree;
-$tree    = $repo -> lookup($tree_id);
+$tree = $index -> write_tree;
 
 $index -> read_tree($tree);
 my @entries = $index -> entries();

--- a/t/09-diff.t
+++ b/t/09-diff.t
@@ -275,12 +275,12 @@ is substr($delta -> new_file -> id, 0, 7), 'c7eaef2';
 
 $index -> add('diff');
 $index -> add('diff2');
-my $index_tree1 = $repo -> lookup($index -> write_tree);
+my $index_tree1 = $index -> write_tree;
 
 move($file, $file.'.moved');
 $index -> remove('diff');
 $index -> add('diff.moved');
-my $index_tree2 = $repo -> lookup($index -> write_tree);
+my $index_tree2 = $index -> write_tree;
 
 my $tree_diff = $index_tree1 -> diff({
 	'tree'   => $index_tree2
@@ -404,7 +404,7 @@ EOS
 
 write_file("$file.moved", $content);
 $index -> add('diff.moved');
-$index_tree1 = $repo -> lookup($index -> write_tree);
+$index_tree1 = $index -> write_tree;
 
 move($file.'.moved', $file);
 $index -> remove('diff.moved');
@@ -419,7 +419,7 @@ EOS
 
 write_file($file, $content);
 $index -> add('diff');
-$index_tree2 = $repo -> lookup($index -> write_tree);
+$index_tree2 = $index -> write_tree;
 
 $tree_diff = $index_tree1 -> diff({
 	'tree'   => $index_tree2,
@@ -480,7 +480,7 @@ EOS
 
 write_file($file, $content);
 $index -> add('diff');
-$index_tree2 = $repo -> lookup($index -> write_tree);
+$index_tree2 = $index -> write_tree;
 
 $tree_diff = $index_tree1 -> diff({
 	'tree'   => $index_tree2,

--- a/t/13-checkout.t
+++ b/t/13-checkout.t
@@ -42,7 +42,7 @@ $index -> add('test2');
 $index -> write;
 $index -> read;
 
-my $tree = $repo -> lookup($index -> write_tree);
+my $tree = $index -> write_tree;
 
 my $name   = $repo -> config -> str('user.name');
 my $email  = $repo -> config -> str('user.email');

--- a/t/15-merge.t
+++ b/t/15-merge.t
@@ -29,7 +29,7 @@ is $config -> str('user.email', $email), $email;
 my $me = Git::Raw::Signature -> default($repo);
 
 my $commit = $repo -> commit("initial commit\n", $me, $me, [],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 my $initial_head = $repo -> head;
 my $branch1 = $repo -> branch('branch1', $initial_head -> target);
@@ -42,7 +42,7 @@ $index -> add('test1');
 $index -> write;
 
 my $commit1 = $repo -> commit("commit on branch1\n", $me, $me, [$branch1 -> target],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 my $master  = Git::Raw::Branch -> lookup($repo, 'master', 1);
 $repo -> checkout($repo -> head($master), {
@@ -105,7 +105,7 @@ $index -> add('test1');
 $index -> write;
 
 my $commit2 = $repo -> commit("commit on branch2\n", $me, $me, [$branch2 -> target],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 $repo -> checkout($repo -> head($master), {
 	'checkout_strategy' => {
@@ -167,7 +167,7 @@ is $merge_msg, "Merge branch 'branch2'\n\nConflicts:\n\ttest1\n";
 
 my $target = $master -> target;
 $commit = $repo -> commit("Merge commit!", $me, $me, [$target, $commit2],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 Git::Raw::Graph -> is_descendant_of($repo, $commit, $target), 1;
 Git::Raw::Graph -> is_descendant_of($repo, $commit, $commit2), 1;
@@ -194,7 +194,7 @@ $index -> add('test1');
 $index -> write;
 
 $commit = $repo -> commit("commit on branch3\n", $me, $me, [$branch3 -> target],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 is (Git::Raw::Graph -> is_descendant_of($repo, $commit, $initial_head), 1);
 is (Git::Raw::Graph -> is_descendant_of($repo, $commit -> id, $initial_head), 1);
@@ -254,14 +254,14 @@ $index -> add('test1');
 $index -> write;
 
 my $merge_commit1 = $repo -> commit("merge commit on branch1\n", $me, $me, [$head_commit],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 write_file($file1, 'post-commit merge');
 $index -> add('test1');
 $index -> write;
 
 my $merge_commit2 = $repo -> commit("merge commit on branch1\n", $me, $me, [$merge_commit1],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 my $merged_index = $merge_commit1 -> merge($merge_commit2, {});
 isa_ok $merged_index, 'Git::Raw::Index';

--- a/t/17-filter.t
+++ b/t/17-filter.t
@@ -145,7 +145,7 @@ is $apply, 0;
 
 my $me = Git::Raw::Signature -> default($repo);
 my $commit1 = $repo -> commit(
-	"Filter commit1\n", $me, $me, [$repo -> head -> target], $repo -> lookup($index -> write_tree)
+	"Filter commit1\n", $me, $me, [$repo -> head -> target], $index -> write_tree
 );
 
 write_file($file, 'X:filter me some more and more:X');
@@ -153,7 +153,7 @@ $index -> add('filterfile');
 $index -> write;
 
 my $commit2 = $repo -> commit(
-	"Filter commit2\n", $me, $me, [$commit1], $repo -> lookup($index -> write_tree)
+	"Filter commit2\n", $me, $me, [$commit1], $index -> write_tree
 );
 
 my $worktree_filter = Git::Raw::Filter -> create ("worktree", "text");

--- a/t/18-blame.t
+++ b/t/18-blame.t
@@ -31,7 +31,7 @@ $index -> write;
 
 my $me = Git::Raw::Signature -> default($repo);
 my $commit1 = $repo -> commit("commit1 on blame branch\n", $me, $me, [$repo -> head -> target],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 @lines = ('line1', 'line2', 'line31', 'line4');
 write_file($file, join("\n", @lines));
@@ -39,7 +39,7 @@ $index -> add('blame');
 $index -> write;
 
 my $commit2 = $repo -> commit("commit2 on blame branch\n", $me, $me, [$repo -> head -> target],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 @lines = ('line1', 'line2', 'line31', 'line41');
 write_file($file, join("\n", @lines));
@@ -47,7 +47,7 @@ $index -> add('blame');
 $index -> write;
 
 my $commit3 = $repo -> commit("commit3 on blame branch\n", $me, $me, [$repo -> head -> target],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 my $blame = $repo -> blame('blame');
 isa_ok $blame, 'Git::Raw::Blame';

--- a/t/19-push.t
+++ b/t/19-push.t
@@ -147,7 +147,7 @@ $index -> write;
 
 my $me = Git::Raw::Signature -> default($repo);
 my $commit = $repo -> commit("commit on file_on_ssh_branch\n", $me, $me, [$branch -> target],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 is scalar(@remotes), 1;
 $remote = shift @remotes;

--- a/t/21-cherrypick.t
+++ b/t/21-cherrypick.t
@@ -30,7 +30,7 @@ is_deeply $repo -> status({}) -> {'cherry_file'} -> {'flags'}, ['index_new'];
 
 my $me = Git::Raw::Signature -> default($repo);
 my $commit1 = $repo -> commit("commit1 on cbranch\n", $me, $me, [$branch -> target],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 is $repo -> status({}) -> {'cherry_file'}, undef;
 
@@ -41,7 +41,7 @@ $index -> write;
 is_deeply $repo -> status({}) -> {'cherry_file'} -> {'flags'}, ['index_modified'];
 
 my $commit2 = $repo -> commit("commit2 on cbranch\n", $me, $me, [$commit1],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 is $repo -> status({}) -> {'cherry_file'}, undef;
 
@@ -62,7 +62,7 @@ is $index -> has_conflicts, 0;
 ok (!eval { $repo -> cherry_pick($commit2) });
 
 my $c_commit1 = $repo -> commit("commit1 on cbranch\n", $me, $me, [$cherry_pick_branch -> target],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 is $repo -> status({}) -> {'cherry_file'}, undef;
 
@@ -75,7 +75,7 @@ is $index -> has_conflicts, 0;
 ok (!eval { $repo -> cherry_pick($commit2) });
 
 my $c_commit2 = $repo -> commit("commit2 on cbranch\n", $me, $me, [$c_commit1],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 is $branch -> target -> tree -> id, $cherry_pick_branch -> target -> tree -> id;
 
@@ -100,7 +100,7 @@ $index -> add('cherry_file');
 $index -> write;
 
 my $conflict_commit1 = $repo -> commit("conflict commit on cbranch\n", $me, $me, [$cherry_pick_conflict_branch -> target],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 ok (!eval { $repo -> cherry_pick($commit2, {}, {}, 9999) });
 $repo -> cherry_pick($commit2, {}, {}, 0);
@@ -111,7 +111,7 @@ $index -> add('cherry_file');
 is $index -> has_conflicts, 0;
 
 my $conflict_commit2 = $repo -> commit("commit2 on cbranch\n", $me, $me, [$conflict_commit1],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 is $index -> has_conflicts, 0;
 is $repo -> status({}) -> {'cherry_file'}, undef;

--- a/t/22-revert.t
+++ b/t/22-revert.t
@@ -30,7 +30,7 @@ is_deeply $repo -> status({}) -> {'revert_file'} -> {'flags'}, ['index_new'];
 
 my $me = Git::Raw::Signature -> default($repo);
 my $commit1 = $repo -> commit("commit1 on rbranch\n", $me, $me, [$branch -> target],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 is $repo -> status({}) -> {'revert_file'}, undef;
 
@@ -41,7 +41,7 @@ $index -> write;
 is_deeply $repo -> status({}) -> {'revert_file'} -> {'flags'}, ['index_modified'];
 
 my $commit2 = $repo -> commit("commit2 on rbranch\n", $me, $me, [$commit1],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 is $repo -> status({}) -> {'revert_file'}, undef;
 
@@ -60,7 +60,7 @@ is_deeply $repo -> status({}) -> {'revert_file'} -> {'flags'}, ['index_modified'
 is read_file($file1), 'this is revert_file';
 
 my $revert_commit = $repo -> commit("revert commit1\n", $me, $me, [$commit2],
-	$repo -> lookup($index -> write_tree));
+	$index -> write_tree);
 
 is_deeply $repo -> status({}) -> {'revert_file'}, undef;
 is $revert_commit -> tree -> id, $commit1 -> tree -> id;


### PR DESCRIPTION
Most of the time, when calling `write_tree()`, you're actually interested in the tree object, as the typical use case is to use this tree for creating a commit.

Return a `Git::Raw::Tree` object instead of the tree's object id. This PR also provides a stringify overload for `Git::Raw::Tree` which will return the tree's object id in order to minimise the impact of this change.
