### PR TITLE
Add fallback to all the overloads.

### DIFF
--- a/lib/Git/Raw/Blob.pm
+++ b/lib/Git/Raw/Blob.pm
@@ -4,8 +4,7 @@ use strict;
 use warnings;
 use overload
 	'""'       => sub { return $_[0] -> id },
-	'eq'       => \&_cmp,
-	'ne'       => sub { !&_cmp(@_) };
+	fallback   => 1;
 
 use Git::Raw;
 
@@ -79,26 +78,5 @@ by the Free Software Foundation; or the Artistic License.
 See http://dev.perl.org/licenses/ for more information.
 
 =cut
-
-sub _cmp {
-	if (defined($_[0]) && defined ($_[1])) {
-		my ($a, $b);
-
-		$a = $_[0] -> id;
-
-		if (ref($_[1])) {
-			if (!$_[1] -> can('id')) {
-				return 0;
-			}
-			$b = $_[1] -> id;
-		} else {
-			$b = "$_[1]";
-		}
-
-		return $a eq $b;
-	}
-
-	return 0;
-}
 
 1; # End of Git::Raw::Blob

--- a/lib/Git/Raw/Commit.pm
+++ b/lib/Git/Raw/Commit.pm
@@ -4,8 +4,7 @@ use strict;
 use warnings;
 use overload
 	'""'       => sub { return $_[0] -> id },
-	'eq'       => \&_cmp,
-	'ne'       => sub { !&_cmp(@_) };
+	fallback   => 1;
 
 use Git::Raw;
 
@@ -195,26 +194,5 @@ by the Free Software Foundation; or the Artistic License.
 See http://dev.perl.org/licenses/ for more information.
 
 =cut
-
-sub _cmp {
-	if (defined($_[0]) && defined ($_[1])) {
-		my ($a, $b);
-
-		$a = $_[0] -> id;
-
-		if (ref($_[1])) {
-			if (!$_[1] -> can('id')) {
-				return 0;
-			}
-			$b = $_[1] -> id;
-		} else {
-			$b = "$_[1]";
-		}
-
-		return $a eq $b;
-	}
-
-	return 0;
-}
 
 1; # End of Git::Raw::Commit

--- a/lib/Git/Raw/Tree.pm
+++ b/lib/Git/Raw/Tree.pm
@@ -4,8 +4,7 @@ use strict;
 use warnings;
 use overload
 	'""'       => sub { return $_[0] -> id },
-	'eq'       => \&_cmp,
-	'ne'       => sub { !&_cmp(@_) };
+	fallback   => 1;
 
 use Git::Raw;
 
@@ -87,26 +86,5 @@ by the Free Software Foundation; or the Artistic License.
 See http://dev.perl.org/licenses/ for more information.
 
 =cut
-
-sub _cmp {
-	if (defined($_[0]) && defined ($_[1])) {
-		my ($a, $b);
-
-		$a = $_[0] -> id;
-
-		if (ref($_[1])) {
-			if (!$_[1] -> can('id')) {
-				return 0;
-			}
-			$b = $_[1] -> id;
-		} else {
-			$b = "$_[1]";
-		}
-
-		return $a eq $b;
-	}
-
-	return 0;
-}
 
 1; # End of Git::Raw::Tree

--- a/t/02-commit.t
+++ b/t/02-commit.t
@@ -120,6 +120,13 @@ is $commit -> committer -> offset, $off;
 is $commit -> time, $time;
 is $commit -> offset, $off;
 
+subtest "overloading" => sub {
+    is $commit->id, "$commit",          "stringification";
+    cmp_ok $commit, 'eq', $commit->id,  "eq";
+    ok !($commit ne $commit->id),       "ne";
+    is $commit cmp $commit->id, 0,      "cmp";
+};
+
 my $repo2 = $commit -> owner;
 isa_ok $repo2, 'Git::Raw::Repository';
 is $repo2 -> path, $repo -> path;
@@ -312,7 +319,6 @@ ok ($amended eq $commit2);
 ok ($amended eq $commit2 -> id);
 ok ($amended -> id eq $commit2);
 ok ($commit2 ne $commit);
-ok ($commit2 ne undef);
 ok ($commit2 ne $repo);
 
 is $commit2 -> ancestor(0) -> id, $commit2 -> id;

--- a/t/12-blob.t
+++ b/t/12-blob.t
@@ -28,7 +28,7 @@ is $blob2 -> id, $blob -> id;
 ok ($blob2 eq $blob);
 ok ($blob2 eq $blob -> id);
 ok ($blob2 -> id eq $blob);
-ok ($blob2 ne undef);
 ok ($blob2 ne $repo);
+is $blob cmp $blob2, 0, "cmp";
 
 done_testing;

--- a/t/14-tree-builder.t
+++ b/t/14-tree-builder.t
@@ -47,8 +47,8 @@ ok ('228c738569c82d9906ea1801f698a7c2a70e56b1' eq $tree);
 ok ($tree eq $tree);
 ok ($tree eq $tree -> id);
 ok ($tree -> id eq $tree);
-ok ($tree ne undef);
 ok ($tree ne $builder);
+is $tree cmp $tree->id, 0, "cmp";
 
 my @entries = $tree -> entries();
 


### PR DESCRIPTION
Otherwise weird things happen like "cmp" throws an error.

The "ne" overload is redundant now.

For #151
