### PR TITLE
Fix reference counting issues

### DIFF
--- a/xs/Commit.xs
+++ b/xs/Commit.xs
@@ -13,7 +13,8 @@ create(class, repo, msg, author, committer, parents, tree, ...)
 	PREINIT:
 		int rc;
 
-		int count;
+		SV **c;
+		size_t i = 0, count = 0;
 		git_oid oid;
 
 		Repository repo_ptr;
@@ -32,19 +33,12 @@ create(class, repo, msg, author, committer, parents, tree, ...)
 				update_ref = NULL;
 		}
 
-		count = av_len(parents) + 1;
+		while ((c = av_fetch(parents, i++, 0))) {
+			if (!c || !SvOK(*c))
+				continue;
 
-		if (count > 0) {
-			int i;
-			SV *iter;
-
-			Newx(commit_parents, count, git_commit *);
-
-			for (i = 0; i < count; i++) {
-				iter = av_shift(parents);
-
-				commit_parents[i] = GIT_SV_TO_PTR(Commit, iter);
-			}
+			Renew(commit_parents, count + 1, git_commit *);
+			commit_parents[count++] = GIT_SV_TO_PTR(Commit, *c);
 		}
 
 		repo_ptr = GIT_SV_TO_PTR(Repository, repo);

--- a/xs/Diff.xs
+++ b/xs/Diff.xs
@@ -155,7 +155,8 @@ patches(self)
 
 void
 DESTROY(self)
-	Diff self
+	SV *self
 
 	CODE:
-		git_diff_free(self);
+		git_diff_free(GIT_SV_TO_PTR(Diff, self));
+		SvREFCNT_dec(GIT_SV_TO_MAGIC(self));

--- a/xs/Repository.xs
+++ b/xs/Repository.xs
@@ -544,15 +544,16 @@ ignore(self, rules)
 		rc = git_ignore_add_rule(self -> repository, git_ensure_pv(rules, "rules"));
 		git_check_error(rc);
 
-Diff
+SV *
 diff(self, ...)
-	Repository self
+	SV *self
 
 	PROTOTYPE: $;$
 
 	PREINIT:
 		int rc;
 
+		Repository repo_ptr;
 		Diff diff;
 		Index index;
 
@@ -561,7 +562,9 @@ diff(self, ...)
 		git_diff_options diff_opts = GIT_DIFF_OPTIONS_INIT;
 
 	CODE:
-		rc = git_repository_index(&index, self -> repository);
+		repo_ptr = GIT_SV_TO_PTR(Repository, self);
+
+		rc = git_repository_index(&index, repo_ptr -> repository);
 		git_check_error(rc);
 
 		if (items == 2) {
@@ -571,11 +574,11 @@ diff(self, ...)
 
 		if (tree) {
 			rc = git_diff_tree_to_index(
-				&diff, self -> repository, tree, index, &diff_opts
+				&diff, repo_ptr -> repository, tree, index, &diff_opts
 			);
 		} else {
 			rc = git_diff_index_to_workdir(
-				&diff, self -> repository, index, &diff_opts
+				&diff, repo_ptr -> repository, index, &diff_opts
 			);
 		}
 
@@ -584,7 +587,9 @@ diff(self, ...)
 			Safefree(diff_opts.pathspec.strings);
 		git_check_error(rc);
 
-		RETVAL = diff;
+		GIT_NEW_OBJ_WITH_MAGIC(
+			RETVAL, "Git::Raw::Diff", diff, SvRV(self)
+		);
 
 	OUTPUT: RETVAL
 


### PR DESCRIPTION
This PR fixes 2 reference count issues:

* When a ```Diff``` object is created, we need to increase the reference count of the ```Repository``` and decrease it when the ```Diff``` is destroyed. This was done inconsistently.
* When creating a ```Commit```, we should not be ```shift```-ing the commit objects off of the list, we only need a weak reference to them.