### PR TITLE
removed PUTBACK after call of diff print callback

### DIFF
--- a/Raw.xs
+++ b/Raw.xs
@@ -1012,7 +1012,6 @@ STATIC int git_diff_cb(const git_diff_delta *delta, const git_diff_hunk *hunk,
 
 	call_sv(coderef, G_DISCARD);
 
-	PUTBACK;
 	FREETMPS;
 	LEAVE;
 


### PR DESCRIPTION
If I use Git::Raw::Diff::print($format, $callback) on large diffs (> 100 lines), I get a memory access error.

The reason seems to be that in Raw.xs git_diff_cb after the call_sv the macro PUTBACK is called
without calling SPAGAIN before.
According to the example http://perldoc.perl.org/perlcall.html#Passing-Parameters the PUTBACK call
after call_pv is not necessary.
If SPAGAIN is called before PUTBACK like in http://perldoc.perl.org/perlcall.html#Returning-a-Scalar, it also works.