### PR TITLE
Support git_remote_delete and git_remote_create_with_fetchspec from remote.c

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal

--- a/lib/Git/Raw/Remote.pm
+++ b/lib/Git/Raw/Remote.pm
@@ -56,6 +56,11 @@ B<WARNING>: The API of this module is unstable and may change without warning
 Create a remote with the default fetch refspec and add it to the repository's
 configuration.
 
+=head2 create_with_fetchspec( $repo, $name, $url, $fetch )
+
+Create a remote with the provided fetch refspec and add it to the repository's
+configuration.
+
 =head2 create_anonymous( $repo, $url )
 
 Create a remote in memory (anonymous).

--- a/lib/Git/Raw/Remote.pm
+++ b/lib/Git/Raw/Remote.pm
@@ -70,6 +70,10 @@ Create a remote in memory (anonymous).
 Load an existing remote. Returns a L<Git::Raw::Remote> object if the remote
 was found, otherwise C<undef>.
 
+=head2 delete( $repo, $name )
+
+Delete an existing remote.
+
 =head2 owner( )
 
 Retrieve the L<Git::Raw::Repository> owning the remote.

--- a/t/07-remote.t
+++ b/t/07-remote.t
@@ -69,6 +69,16 @@ is $refspec -> dst, "refs/tags/v0.0.1";
 is $refspec -> direction, "fetch";
 is $refspec -> string, "refs/tags/v0.0.1:refs/tags/v0.0.1";
 $customfetch = undef;
+@remotes = $repo -> remotes;
+is scalar(@remotes), 3;
+Git::Raw::Remote -> delete($repo,'tagfetch');
+@remotes = $repo -> remotes;
+is scalar(@remotes), 2;
+@remotes = ();
+
+
+
+
 
 
 $name = 'github';

--- a/t/07-remote.t
+++ b/t/07-remote.t
@@ -59,6 +59,18 @@ is $remotes[0] -> url, $url;
 is $remotes[1] -> name, 'post_rename';
 @remotes = ();
 
+
+$customfetch = Git::Raw::Remote -> create_with_fetchspec($repo, 'tagfetch', $url, "refs/tags/v0.0.1:refs/tags/v0.0.1" );
+@refspecs = $customfetch -> refspecs;
+is scalar(@refspecs), 1;
+$refspec = shift @refspecs;
+is $refspec -> src, "refs/tags/v0.0.1";
+is $refspec -> dst, "refs/tags/v0.0.1";
+is $refspec -> direction, "fetch";
+is $refspec -> string, "refs/tags/v0.0.1:refs/tags/v0.0.1";
+$customfetch = undef;
+
+
 $name = 'github';
 $url  = 'git://github.com/libgit2/TestGitRepository.git';
 

--- a/xs/Remote.xs
+++ b/xs/Remote.xs
@@ -132,6 +132,26 @@ load(class, repo, name)
 
 	OUTPUT: RETVAL
 
+void
+delete(class, repo, name)
+	SV *class
+	SV *repo
+	SV *name
+
+	PREINIT:
+		int rc;
+
+		git_remote *r = NULL;
+		Repository repo_ptr = NULL;
+
+	CODE:
+		repo_ptr = GIT_SV_TO_PTR(Repository, repo);
+		rc = git_remote_delete(repo_ptr -> repository,
+                        git_ensure_pv(name, "name"));
+
+		git_check_error(rc);
+
+
 SV *
 owner(self)
 	SV *self

--- a/xs/Remote.xs
+++ b/xs/Remote.xs
@@ -33,6 +33,41 @@ create(class, repo, name, url)
 	OUTPUT: RETVAL
 
 SV *
+create_with_fetchspec(class, repo, name, url, spec)
+	SV *class
+	SV *repo
+	SV *name
+	SV *url
+	SV *spec
+
+	PREINIT:
+		int rc;
+
+		git_remote *r = NULL;
+		Remote remote = NULL;
+		Repository repo_ptr = NULL;
+
+	CODE:
+		repo_ptr = GIT_SV_TO_PTR(Repository, repo);
+		rc = git_remote_create_with_fetchspec(
+			&r, repo_ptr -> repository,
+			git_ensure_pv(name, "name"),
+                        git_ensure_pv(url, "url"),
+                        git_ensure_pv(spec, "spec")
+		);
+		git_check_error(rc);
+
+		Newxz(remote, 1, git_raw_remote);
+		remote -> remote = r;
+		remote -> owned = 1;
+
+		GIT_NEW_OBJ_WITH_MAGIC(
+			RETVAL, SvPVbyte_nolen(class), remote, SvRV(repo)
+		);
+
+	OUTPUT: RETVAL
+
+SV *
 create_anonymous(class, repo, url)
 	SV *class
 	SV *repo


### PR DESCRIPTION
Needed to update Remote.pm for one of my projects to provide:

- delete -> remote.c/git_remote-delete
- create_with_fetchspec -> remote.c/git_remote_create_with_fetchspec

