### PR TITLE
Add option to set file mode when adding to index

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,3 +1,4 @@
+MYMETA.json.lock
 Raw.bs
 Raw.c
 Raw.o

--- a/lib/Git/Raw/Index.pm
+++ b/lib/Git/Raw/Index.pm
@@ -31,11 +31,12 @@ Retrieve the L<Git::Raw::Repository> owning the index.
 Add C<$entry> to the index. C<$entry> should either be the path of a file
 or alternatively a L<Git::Raw::Index::Entry>.
 
-=head2 add_frombuffer( $path, $buffer )
+=head2 add_frombuffer( $path, $buffer, [$mode] )
 
 Add or update an entry from an in memory file. The entry will be placed at C<$path>
 with the contents of C<$buffer>. C<$buffer> may either be string or a reference
-to a string. Returns a L<Git::Raw::Index::Entry> object.
+to a string. C<$mode> is the file mode; it defaults to C<0100644>. Returns a
+L<Git::Raw::Index::Entry> object.
 
 =head2 add_all( \%opts )
 

--- a/t/01-repo.t
+++ b/t/01-repo.t
@@ -64,7 +64,7 @@ is $index -> version, 2;
 $index -> version(4);
 is $index -> version, 4;
 
-ok (eval { $index -> capabilities });
+ok (eval { $index -> capabilities; return 1 });
 
 my $caps_count = $index -> capabilities;
 is $caps_count, 3;

--- a/t/23-diagnostics.t
+++ b/t/23-diagnostics.t
@@ -7,7 +7,7 @@ use Git::Raw;
 my $count;
 my %features;
 
-ok (eval { Git::Raw -> features });
+ok (eval { Git::Raw -> features; return 1 });
 
 ok (eval { $count = Git::Raw -> features });
 is $count, 3;

--- a/xs/Index.xs
+++ b/xs/Index.xs
@@ -38,7 +38,7 @@ add(self, entry)
 		git_check_error(rc);
 
 SV *
-add_frombuffer(self, path, buffer)
+add_frombuffer(self, path, buffer, ...)
 	SV *self
 	SV *path
 	SV *buffer
@@ -50,8 +50,12 @@ add_frombuffer(self, path, buffer)
 		git_index_entry ientry;
 		const char *b;
 		STRLEN len;
+		int mode = GIT_FILEMODE_BLOB;
 
 	CODE:
+		if (items == 4)
+			mode = (int) git_ensure_iv(ST(3), "mode");
+
 		index = GIT_SV_TO_PTR(Index, self);
 
 		if (!SvOK(buffer))
@@ -61,7 +65,7 @@ add_frombuffer(self, path, buffer)
 			buffer = SvRV(buffer);
 
 		memset(&ientry, 0x0, sizeof(git_index_entry));
-		ientry.mode = GIT_FILEMODE_BLOB;
+		ientry.mode = mode;
 		ientry.path = git_ensure_pv(path, "path");
 
 		b = git_ensure_pv_with_len(buffer, "buffer", &len);


### PR DESCRIPTION
Instead of assuming all files being added from an in-memory buffer are
non-executable blobs, give callers the option to specify the mode to
better approximate git-update-index --cacheinfo.  For backwards
compatibility, the mode is optional and defaults to 0100644.