### PR TITLE
Allow refspecs to be specified at download/fetch time

### DIFF
--- a/lib/Git/Raw.pm
+++ b/lib/Git/Raw.pm
@@ -19,6 +19,7 @@ use Git::Raw::Odb;
 use Git::Raw::Odb::Object;
 use Git::Raw::Mempack;
 use Git::Raw::Rebase;
+use Git::Raw::RefSpec;
 use Git::Raw::Reference;
 use Git::Raw::Repository;
 use Git::Raw::Stash;

--- a/lib/Git/Raw/RefSpec.pm
+++ b/lib/Git/Raw/RefSpec.pm
@@ -2,6 +2,9 @@ package Git::Raw::RefSpec;
 
 use strict;
 use warnings;
+use overload
+	'""'       => sub { return $_[0] -> string },
+	fallback   => 1;
 
 =head1 NAME
 

--- a/lib/Git/Raw/Remote.pm
+++ b/lib/Git/Raw/Remote.pm
@@ -140,11 +140,13 @@ The local OID of the reference (optional).
 
 =back
 
-=head2 fetch( [ \%fetch_opts ] )
+=head2 fetch( [ \%fetch_opts, [ \@refspecs ] ] )
 
 Download new data and update tips. Convenience function to connect to a remote,
-download the data, disconnect and update the remote-tracking branches. Valid fields for
-the C<%fetch_opts> hash are:
+download the data, disconnect and update the remote-tracking branches.
+C<@refspecs> is an optional list of refspecs to use for the negotiation with
+the server to determine the missing objects that need to be downloaded.  Valid
+fields for the C<%fetch_opts> hash are:
 
 =over 4
 
@@ -195,10 +197,10 @@ Connect to the remote. The C<$direction> should either be C<"fetch"> or C<"push"
 
 Disconnect the remote.
 
-=head2 download( [ \%fetch_opts ] )
+=head2 download( [ \%fetch_opts, [ \@refspecs ] ] )
 
 Download the remote packfile. See C<Git::Raw::Remote-E<gt>fetch()> for valid
-C<%fetch_opts> values.
+C<%fetch_opts> and C<@refspecs> values.
 
 =head2 upload( \@refspecs, [ \%push_opts ] )
 

--- a/t/07-remote.t
+++ b/t/07-remote.t
@@ -179,6 +179,20 @@ my $ls = $github -> ls;
 
 is_deeply $ls -> {'HEAD'}, $ls -> {'refs/heads/master'};
 
+$path = rel2abs(catfile('t', 'refspecs_repo'));
+make_path($path);
+
+$repo = Git::Raw::Repository -> init ($path, 0);
+$github = Git::Raw::Remote -> create_anonymous($repo, $url);
+
+$github->download({}, ['refs/heads/no-parent:']);
+
+isa_ok $repo->lookup($ls -> {'refs/heads/no-parent'} -> {'id'}), 'Git::Raw::Commit';
+is $repo->lookup($ls -> {'refs/heads/master'} -> {'id'}), undef;
+
+rmtree $path;
+ok ! -e $path;
+
 $path = rel2abs(catfile('t', 'callbacks_repo'));
 make_path($path);
 

--- a/t/07-remote.t
+++ b/t/07-remote.t
@@ -38,6 +38,7 @@ is $refspec -> src_matches('refs/heads/master'), 1;
 is $refspec -> rtransform ('refs/remotes/github/master'), "refs/heads/master";
 is $refspec -> dst_matches('refs/remotes/github/master'), 1;
 is $refspec -> dst_matches('refs/remotes/blah/master'), 0;
+is $refspec, $refspec -> string;
 
 my $rename = Git::Raw::Remote -> create($repo, 'pre_rename', $url);
 is $rename -> name, 'pre_rename';

--- a/xs/Remote.xs
+++ b/xs/Remote.xs
@@ -360,6 +360,8 @@ fetch(self, ...)
 		int rc;
 
 		git_fetch_options fetch_opts = GIT_FETCH_OPTIONS_INIT;
+		git_strarray specs = {NULL, 0};
+		git_strarray *refspecs = NULL;
 
 	CODE:
 		if (items >= 2) {
@@ -367,9 +369,20 @@ fetch(self, ...)
 			git_hv_to_fetch_opts(opts, &fetch_opts);
 		}
 
-		rc = git_remote_fetch(self -> remote, NULL,
+		if (items >= 3) {
+			git_list_to_paths(
+				git_ensure_av(ST(2), "refspecs"),
+				&specs
+			);
+			refspecs = &specs;
+		}
+
+		rc = git_remote_fetch(self -> remote, refspecs,
 			&fetch_opts, NULL
 		);
+		if (refspecs) {
+			Safefree(specs.strings);
+		}
 		git_check_error(rc);
 
 void
@@ -449,6 +462,8 @@ download(self, ...)
 		int rc;
 
 		git_fetch_options fetch_opts = GIT_FETCH_OPTIONS_INIT;
+		git_strarray specs = {NULL, 0};
+		git_strarray *refspecs = NULL;
 
 	CODE:
 		if (items >= 2) {
@@ -456,9 +471,20 @@ download(self, ...)
 			git_hv_to_fetch_opts(opts, &fetch_opts);
 		}
 
-		rc = git_remote_download(self -> remote, NULL,
+		if (items >= 3) {
+			git_list_to_paths(
+				git_ensure_av(ST(2), "refspecs"),
+				&specs
+			);
+			refspecs = &specs;
+		}
+
+		rc = git_remote_download(self -> remote, refspecs,
 			&fetch_opts
 		);
+		if (refspecs) {
+			Safefree(specs.strings);
+		}
 		git_check_error(rc);
 
 void


### PR DESCRIPTION
Add an optional argument to `Remote`'s `fetch()` and `download()` that takes an array of refspecs to download.  Additionally, update `RefSpec` objects so they stringify to an actual refspec.

This change allows authors to limit the number of references downloaded, for better transfer times and reduced storage costs.  It also allows anonymous remotes to fetch data.