### PR TITLE
Spelling etc. in documentation

### DIFF
--- a/lib/Git/Raw/Filter.pm
+++ b/lib/Git/Raw/Filter.pm
@@ -18,18 +18,18 @@ B<WARNING>: The API of this module is unstable and may change without warning
 
 =head1 METHODS
 
-=head2 create( $name, $attributes)
+=head2 create( $name, $attributes )
 
 Create a filter. C<$name> is a name by which the filter can be referenced.
 C<$attributes> is a whitespace-separated list of attribute names to check for
 this filter (e.g. C<"eol crlf text">). If the attribute name is bare, it will
-be simply loaded and passed to the C<"check"> callback.  If it has a value
+simply be loaded and passed to the C<"check"> callback.  If it has a value
 (i.e. "name=value"), the attribute must match that value for the filter to
 be applied.
 
 =head2 callbacks( \%callbacks )
 
-Set the callbacks for the filter. C<%callbacks> may specificy the following
+Set the callbacks for the filter. C<%callbacks> may specify the following
 callbacks.
 
 =over 4

--- a/lib/Git/Raw/Note.pm
+++ b/lib/Git/Raw/Note.pm
@@ -27,7 +27,7 @@ L<Git::Raw::Note> object.
 =head2 read( $repo, $commitish, [$refname] )
 
 Read the note for C<$commitish>. Returns a L<Git::Raw::Note> object if a note
-is associated with C<$commitish>, otherise C<undef>.
+is associated with C<$commitish>, otherwise C<undef>.
 
 =head2 remove( $repo, $commitish, [$refname] )
 

--- a/lib/Git/Raw/Remote.pm
+++ b/lib/Git/Raw/Remote.pm
@@ -53,8 +53,8 @@ B<WARNING>: The API of this module is unstable and may change without warning
 
 =head2 create( $repo, $name, $url, [$fetch] )
 
-Create a remote with the default fetch refspec or C<$fetch> if provideed, and add
-it to the repository's configuration.
+Create a remote with the default fetch refspec or C<$fetch> if
+provided, and add it to the repository's configuration.
 
 =head2 create_anonymous( $repo, $url )
 
@@ -89,7 +89,7 @@ Retrieve the name of the remote.
 
 =head2 rename( $repo, $old_name, $new_name, [ \@problems ] )
 
-Rename a remote. Non-default refspecs cannot be renamed and will be store in
+Rename a remote. Non-default refspecs cannot be renamed and will be stored in
 C<@problems> if provided.
 
 =head2 url( [ $url ] )


### PR DESCRIPTION
These are some spelling errors I noticed when reading the documentation.
